### PR TITLE
mdx で試した時の問題に対する修正

### DIFF
--- a/docker_sample/Dockerfile
+++ b/docker_sample/Dockerfile
@@ -11,7 +11,9 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # vLLMのインストール
-RUN pip install --no-cache-dir vllm
+RUN pip install --no-cache-dir vllm nvidia-ml-py && \
+    pip uninstall --yes pynvml && \
+    pip install -U --no-cache-dir opencv-python-headless==4.5.5.62 openai
 
 # モデルファイルをイメージに取り込む (FIXME: モデルファイルのパスを変更)
 COPY ./models/llm-jp/llm-jp-3-1.8b-instruct /workspace/model

--- a/docker_sample/Dockerfile
+++ b/docker_sample/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 # vLLMのインストール
 RUN pip install --no-cache-dir vllm nvidia-ml-py && \
     pip uninstall --yes pynvml && \
-    pip install -U --no-cache-dir opencv-python-headless==4.5.5.62 openai
+    pip install -U --no-cache-dir opencv-python-headless==4.5.5.62
 
 # モデルファイルをイメージに取り込む (FIXME: モデルファイルのパスを変更)
 COPY ./models/llm-jp/llm-jp-3-1.8b-instruct /workspace/model

--- a/docker_sample/README.md
+++ b/docker_sample/README.md
@@ -72,7 +72,6 @@ sudo docker load < [チームID].tar
 
 ```bash
 docker run --rm \
-  --runtime=nvidia \
   --gpus all \
   --network none \
   -v "$(pwd)/data:/data" \


### PR DESCRIPTION
お疲れ様です。
こちら、自分が mdx で試した時に問題だったところの修正案です。

```
+ RUN pip install --no-cache-dir vllm
- RUN pip install --no-cache-dir vllm nvidia-ml-py && \
-     pip uninstall --yes pynvml && \
-     pip install -U --no-cache-dir opencv-python-headless==4.5.5.62
``` 

実行の際、ライブラリ問題でエラーがあったのでそれを対応するものです。
具体的には vllm の中でnvidia-ml-pyとpynvmlのConflictがあるのと、
OpencvのLibファイル関連で問題が起こるものに対応しています。

```
-   --runtime=nvidia \
```

こちらはなくてもGPU利用に問題がなく、dockerのバージョン次第で読み込めなかったので削除しています。
自分はDocker version 27.1.2でした。

```
+ # see more examples at https://github.com/vllm-project/vllm/tree/main/examples
+ chat_template = "{{ (messages|selectattr('role', 'equalto', 'system')|list|last).content|trim if (messages|selectattr('role', 'equalto', 'system')|list) else '' }}\n\n{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ message['content']|trim -}}\n{% if not loop.last %}\n\n\n{% endif %}\n{% elif message['role'] == 'assistant' %}\n{{ message['content']|trim -}}\n{% if not loop.last %}\n\n\n{% endif %}\n{% elif message['role'] == 'user_context' %}\n{{ message['content']|trim -}}\n{% if not loop.last %}\n\n\n{% endif %}\n{% endif %}\n{% endfor %}\n"
```

Transformers 4.44以降では、デフォルトのチャットテンプレートをサポートしないので、
元のコードだけエラーを起こすため、手動で適当なテンプレートを指定しています。

```
-     outputs = llm.chat(messages_list)
```

問題全部を一度で渡すと、コンテキスト長が長くなってしまいエラーが起こっていたので、
一問ずつ投げるように修正しました。


これらは自分が勝手に修正しているものですので、
もしより良い修正案がございましたらそれに従います。
ご確認のほど、よろしくお願いいたします。